### PR TITLE
Fix GCC 10 compiling (-fno-common)

### DIFF
--- a/src/pymountboot.h
+++ b/src/pymountboot.h
@@ -27,6 +27,6 @@ typedef struct
 	enum mountpoint_status status;
 } BootMountpoint;
 
-PyTypeObject BootMountpointType;
+extern PyTypeObject BootMountpointType;
 
 #endif /*PYMOUNTBOOT_H*/


### PR DESCRIPTION
Fix compiling with GCC 10 (-fno-common option).

Fixes https://bugs.gentoo.org/706956